### PR TITLE
Fixed missing extend() method when leaflet.draw plugin is not used

### DIFF
--- a/leaflet.snap.js
+++ b/leaflet.snap.js
@@ -105,7 +105,7 @@ L.Handler.MarkerSnap = L.Handler.extend({
 
 
 L.Edit = L.Edit || {};
-L.Edit.Poly = L.Edit.Poly || {};
+L.Edit.Poly = L.Edit.Poly || { extend: function () {} };
 
 L.Handler.PolylineSnap = L.Edit.Poly.extend({
 


### PR DESCRIPTION
Fixes issue #2
