### PR TITLE
Fixed check for Leaflet.draw

### DIFF
--- a/leaflet.snap.js
+++ b/leaflet.snap.js
@@ -126,7 +126,7 @@ L.Handler.MarkerSnap = L.Handler.extend({
 });
 
 
-if (!L.Edit.Poly) {
+if (!L.Edit) {
     // Leaflet.Draw not available.
     return;
 }


### PR DESCRIPTION
L.Edit.Poly check threw an error if Leaflet.draw is not available, as the L.Edit object is undefined.
