### PR TITLE
Extract finding of closet marker to own function so it can be overridden

### DIFF
--- a/leaflet.snap.js
+++ b/leaflet.snap.js
@@ -96,13 +96,17 @@ L.Handler.MarkerSnap = L.Handler.extend({
             processGuide.call(this, guide);
         }
 
-        var closest = L.GeometryUtil.closestLayerSnap(this._map,
-                                                      snaplist,
-                                                      latlng,
-                                                      this.options.snapDistance,
-                                                      this.options.snapVertices);
+        var closest = this._findClosestLayerSnap(this._map,
+                                                 snaplist,
+                                                 latlng,
+                                                 this.options.snapDistance,
+                                                 this.options.snapVertices);
         closest = closest || {layer: null, latlng: null};
         this._updateSnap(marker, closest.layer, closest.latlng);
+    },
+
+    _findClosestLayerSnap: function (map, layers, latlng, tolerance, withVertices) {
+        return L.GeometryUtil.closestLayerSnap(map, layers, latlng, tolerance, withVertices);
     },
 
     _updateSnap: function (marker, layer, latlng) {


### PR DESCRIPTION
I have a case where I extend `MarkerSnap` to override `closestLayerSnap` to do some custom filtering of snaplist based on the current state of those items. To do so I have extracted the function so it can be overridden. This might be usefull for more people. If not, I'll keep it in my own branch.