### PR TITLE
Drop http: and use // to allow HTTP or HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
     <title>Leaflet.Snap</title>
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
+    <link rel="stylesheet" href="h//cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
     <link rel="stylesheet" href="Leaflet.draw/dist/leaflet.draw.css" />
 
-    <script src="http://cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
+    <script src="//cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>
     <script src="Leaflet.draw/dist/leaflet.draw.js"></script>
     <script src="Leaflet.GeometryUtil/dist/leaflet.geometryutil.js"></script>
 
@@ -58,13 +58,13 @@
 
     <p class="help">Move stuff around and it will snap !
       <a class="sources" href="http://github.com/makinacorpus/Leaflet.Snap/">Sources</a>
-      <a class="logo" href="http://makina-corpus.com"><img src="http://depot.makina-corpus.org/public/logo.gif"/></a>
+      <a class="logo" href="http://makina-corpus.com"><img src="//depot.makina-corpus.org/public/logo.gif"/></a>
     </p>
     <div id="map"></div>
 
     <script type="text/javascript">
 
-        var osm = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        var osm = L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: 'Map data &copy; 2013 OpenStreetMap contributors',
         });
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Leaflet.Snap</title>
 
-    <link rel="stylesheet" href="h//cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
+    <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7/leaflet.css" />
     <link rel="stylesheet" href="Leaflet.draw/dist/leaflet.draw.css" />
 
     <script src="//cdn.leafletjs.com/leaflet-0.7/leaflet.js"></script>


### PR DESCRIPTION
Starting the source with // allows the browser to choose HTTP or HTTPS, depending on what the page's security is.

My friend has a plugin (HTTPS Everywhere) and was unable to view the site